### PR TITLE
tap-highlight/spinbutton

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -59,6 +59,16 @@ body {
   margin-bottom: 10px; /* Space between textbox and clear button */
 }
 
+/* Remove spin buttons on desktop browsers */
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+input[type="number"] {
+  appearance: textfield; /* For Firefox */
+}
+
 #clearButton {
   width: 220px;
   padding: 10px;

--- a/styles.css
+++ b/styles.css
@@ -37,6 +37,7 @@ body {
   line-height: 1; /* Ensure text is vertically centered */
   cursor: pointer;
   user-select: none;
+  -webkit-tap-highlight-color: transparent; /* Remove blue tap hightlight in mobile Chrome */
 }
 
 .key:hover {


### PR DESCRIPTION
- Removes the blue tap highlight in mobile Chrome (try pressing one of the number keys in mobile Chrome)
- Removes spin buttons in desktop Chrome and Firefox

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Enhanced the mobile experience by removing distracting tap highlights.
	- Refined the appearance of number input fields for a cleaner, more consistent user interface across desktop and various browsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->