### PR TITLE
Added a 'Fork me on GitHub' ribbon to the demo page

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,11 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
+    <div class="forkme">
+        <a href="https://github.com/Chizzoz/visual-number-pattern" target="_blank">
+            <img src="https://github.blog/wp-content/uploads/2008/12/forkme_right_darkblue_121621.png?resize=149%2C149" alt="Fork me on GitHub">
+        </a>
+    </div>
     <div class="keypad">
         <div class="row">
             <div class="key" data-number="1">1</div>

--- a/styles.css
+++ b/styles.css
@@ -10,7 +10,9 @@ body {
 }
 
 .forkme {
-  position: fixed; top: 0; right: 0
+  position: fixed; 
+  top: 0; 
+  right: 0;
 }
 
 .keypad {

--- a/styles.css
+++ b/styles.css
@@ -9,6 +9,10 @@ body {
   overflow-y: auto; /* Make body scrollable if content exceeds viewport height */
 }
 
+.forkme {
+  position: fixed; top: 0; right: 0
+}
+
 .keypad {
   position: relative;
   display: grid;


### PR DESCRIPTION
This pull request introduces a "Fork Me on GitHub" ribbon to the project.
It’s positioned to be easily noticeable and includes a clickable link that redirects to the project’s GitHub page, making it easier for contributors to get involved and make their own copy of the repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a "Fork me on GitHub" banner at the top of the page, featuring a clickable image that opens the GitHub repository in a new tab.
	- Enhanced page design with a fixed-position element for easier access to the GitHub repository without affecting existing content or functionality.
- **Styles**
	- Added a new CSS class `.forkme` for the banner, styled to be fixed at the top right corner of the viewport.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->